### PR TITLE
Upgrading to grails 2.4.0

### DIFF
--- a/CacheRedisGrailsPlugin.groovy
+++ b/CacheRedisGrailsPlugin.groovy
@@ -36,8 +36,8 @@ class CacheRedisGrailsPlugin {
 
 	private final Logger log = LoggerFactory.getLogger('grails.plugin.cache.CacheRedisGrailsPlugin')
 
-	String version = '1.0.0'
-	String grailsVersion = '2.0 > *'
+	String version = '1.1.0'
+	String grailsVersion = '2.4 > *'
 	def loadAfter = ['cache']
 	def pluginExcludes = [
 		'grails-app/conf/*CacheConfig.groovy',

--- a/application.properties
+++ b/application.properties
@@ -1,1 +1,3 @@
-app.grails.version=2.0.4
+#Grails Metadata file
+#Sat May 24 23:58:08 CDT 2014
+app.grails.version=2.4.0

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -1,7 +1,9 @@
 grails.project.work.dir = 'target'
 grails.project.docs.output.dir = 'docs/manual' // for gh-pages branch
-grails.project.source.level = 1.6
+grails.project.source.level = 1.7
+grails.project.target.level = 1.7
 
+grails.project.dependency.resolver = "maven" // or ivy
 grails.project.dependency.resolution = {
 
 	inherits 'global'
@@ -10,18 +12,19 @@ grails.project.dependency.resolution = {
 	repositories {
 		grailsCentral()
 		mavenLocal()
-		mavenCentral()
+    mavenCentral()
 	}
 
 	dependencies {
-		compile 'redis.clients:jedis:2.0.0'
-		compile 'org.springframework.data:spring-data-redis:1.0.0.RELEASE'
+		compile 'redis.clients:jedis:2.4.2'
+    compile 'org.springframework:spring-expression:4.0.2.RELEASE'
+		compile 'org.springframework.data:spring-data-redis:1.3.0.RELEASE'
 	}
 
 	plugins {
-		build(':release:2.0.4', ':rest-client-builder:1.0.2') {
+		build(':release:3.0.1', ':rest-client-builder:2.0.1') {
 			export = false
 		}
-		compile ':cache:1.0.0'
+		compile ':cache:1.1.3'
 	}
 }

--- a/src/java/grails/plugin/cache/redis/GrailsRedisCache.java
+++ b/src/java/grails/plugin/cache/redis/GrailsRedisCache.java
@@ -94,6 +94,16 @@ public class GrailsRedisCache implements GrailsCache {
 		}, true);
 	}
 
+    public <T> T get(final Object key, Class<T> type) {
+		return (T) template.execute(new RedisCallback<T>() {
+			public T doInRedis(RedisConnection connection) throws DataAccessException {
+				waitForLock(connection);
+				byte[] bs = connection.get(computeKey(key));
+				return (T)template.getValueSerializer().deserialize(bs);
+			}
+		}, true);
+    }
+
 	protected GrailsValueWrapper newValueWrapper(Object value) {
 		return value == null ? null : new GrailsValueWrapper(value, null);
 	}

--- a/test/integration/grails/plugin/cache/ConfigLoaderTests.groovy
+++ b/test/integration/grails/plugin/cache/ConfigLoaderTests.groovy
@@ -14,12 +14,18 @@
  */
 package grails.plugin.cache
 
+import grails.test.mixin.TestMixin
+import grails.test.mixin.integration.IntegrationTestMixin 
+
+import static org.junit.Assert.*
+
 /**
  * From the core plugin to ensure things work the same way in this plugin.
  *
  * @author Burt Beckwith
  */
-class ConfigLoaderTests extends GroovyTestCase {
+@TestMixin(IntegrationTestMixin)
+class ConfigLoaderTests {
 
 	def grailsApplication
 	def grailsCacheConfigLoader
@@ -82,13 +88,11 @@ class ConfigLoaderTests extends GroovyTestCase {
 		             grailsCacheManager.cacheNames.sort())
 	}
   
-	protected void setUp() {
-		super.setUp()
+	public void setUp() {
 		reset()
 	}
   
-	protected void tearDown() {
-		super.tearDown()
+	public void tearDown() {
 		reset()
 	}
   


### PR DESCRIPTION
This works with grails 2.4.0, and current jedis version.

Integration tests work correctly, using this in a project and works OK for services. Didn't check webtests since I didn't see them running now
