### PR TITLE
GPCACHEREDIS-3: Add TTL support to grails-redis-cache plugin.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,15 @@
+# Eclipse
+.classpath
+.project
+.settings/
+target-eclipse/
+
+# Intellij
+.idea/
+*.iml
+*.iws
+*.ipr
+
 *.zip
 /plugin.xml
 *.log

--- a/CacheRedisGrailsPlugin.groovy
+++ b/CacheRedisGrailsPlugin.groovy
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 import grails.plugin.cache.ConfigBuilder
+import grails.plugin.cache.redis.GrailsRedisCache
 import grails.plugin.cache.redis.GrailsRedisCacheManager
 import grails.plugin.cache.web.filter.redis.GrailsDeserializer
 import grails.plugin.cache.web.filter.redis.GrailsDeserializingConverter
@@ -36,7 +37,7 @@ class CacheRedisGrailsPlugin {
 
 	private final Logger log = LoggerFactory.getLogger('grails.plugin.cache.CacheRedisGrailsPlugin')
 
-	String version = '1.1.1-SNAPSHOT'
+	String version = '1.1.2-SNAPSHOT'
 	String grailsVersion = '2.4 > *'
 	def loadAfter = ['cache']
 	def pluginExcludes = [
@@ -67,10 +68,11 @@ class CacheRedisGrailsPlugin {
 		def redisCacheConfig = cacheConfig.redis
 		int database = redisCacheConfig.database ?: 0
 		boolean usePool = (redisCacheConfig.usePool instanceof Boolean) ? redisCacheConfig.usePool : true
-		String hostName = redisCacheConfig.hostName ?: 'localhost'
+        String hostName = redisCacheConfig.hostName ?: 'localhost'
 		int port = redisCacheConfig.port ?: Protocol.DEFAULT_PORT
 		int timeout = redisCacheConfig.timeout ?: Protocol.DEFAULT_TIMEOUT
 		String password = redisCacheConfig.password ?: null
+        Long ttlInSeconds = cacheConfig.ttl ?: GrailsRedisCache.NEVER_EXPIRE
 
 		grailsCacheJedisPoolConfig(JedisPoolConfig)
 
@@ -117,6 +119,7 @@ class CacheRedisGrailsPlugin {
 
 		grailsCacheManager(GrailsRedisCacheManager, ref('grailsCacheRedisTemplate')) {
 			cachePrefix = ref('redisCachePrefix')
+            timeToLive = ttlInSeconds
 		}
 
 		grailsCacheFilter(RedisPageFragmentCachingFilter) {

--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -6,6 +6,8 @@ log4j = {
 }
 
 // for tests
+grails.cache.ttl = 10
+
 grails.cache.config = {
 	cache {
 		name 'fromConfigGroovy1'

--- a/src/docs/guide/usage/dsl.gdoc
+++ b/src/docs/guide/usage/dsl.gdoc
@@ -1,5 +1,12 @@
 Like the core plugin, there are no cache configuration options beyond the cache name. The DSL parser is lenient though, so you can reuse more complex configurations (for example from the richer Ehcache plugin's DSL implementation) and options that aren't valid will be ignored.
 
-{warning}
-Since there is no way to configure "time to live" with this plugin, all cached items have no timeout and remain cached until either the JVM restarts (since the backing store is in-memory) or the cache is partially or fully cleared (by calling a method or action annotated with \@CacheEvict or programmatically).
-{warning}
+h3. TTL
+TTL is supported at a global level by setting the 'grails.cache.ttl' property in Config.groovy equal to a number of seconds.
+
+For example, to set all cache entries to expire in 3 seconds an entry in Config.groovy should look like the following:
+
+{code}
+grails.cache.ttl = 3
+{code}
+
+Without the above configuration the grails-redis-cache plugin will default to never expire a cache entry.

--- a/src/java/grails/plugin/cache/redis/GrailsRedisCacheManager.java
+++ b/src/java/grails/plugin/cache/redis/GrailsRedisCacheManager.java
@@ -41,6 +41,7 @@ public class GrailsRedisCacheManager implements GrailsCacheManager {
 	protected final RedisTemplate redisTemplate;
 	protected boolean usePrefix;
 	protected RedisCachePrefix cachePrefix = new DefaultRedisCachePrefix();
+    protected Long ttl;
 
 	public GrailsRedisCacheManager(@SuppressWarnings("rawtypes") RedisTemplate template) {
 		redisTemplate = template;
@@ -50,7 +51,7 @@ public class GrailsRedisCacheManager implements GrailsCacheManager {
 	public Cache getCache(String name) {
 		Cache c = caches.get(name);
 		if (c == null) {
-			c = new GrailsRedisCache(name, (usePrefix ? cachePrefix.prefix(name) : null), redisTemplate);
+			c = new GrailsRedisCache(name, (usePrefix ? cachePrefix.prefix(name) : null), redisTemplate, ttl);
 			caches.put(name, c);
 		}
 
@@ -83,4 +84,10 @@ public class GrailsRedisCacheManager implements GrailsCacheManager {
 	public void setCachePrefix(RedisCachePrefix prefix) {
 		cachePrefix = prefix;
 	}
+
+    /**
+     * Sets the cache's time to live.
+     * @param ttl Time to live in seconds.
+     */
+    public void setTimeToLive(Long ttl) { this.ttl = ttl; }
 }

--- a/test/unit/grails/plugin/cache/redis/GrailsRedisCacheManagerSpec.groovy
+++ b/test/unit/grails/plugin/cache/redis/GrailsRedisCacheManagerSpec.groovy
@@ -1,0 +1,37 @@
+package grails.plugin.cache.redis
+
+import org.springframework.data.redis.core.RedisTemplate
+import spock.lang.Specification
+
+class GrailsRedisCacheManagerSpec extends Specification {
+
+    def 'it should default expiration to never expire for all created caches when creating a cache manager with a null ttl value.'() {
+        given:
+        Long ttl = null
+        RedisTemplate template = Mock(RedisTemplate)
+        GrailsRedisCacheManager cacheManager = new GrailsRedisCacheManager(template)
+
+        when: cacheManager.setTimeToLive(ttl)
+
+        and: GrailsRedisCache cache = cacheManager.getCache('book')
+
+        then:
+
+        assert cache.ttl == GrailsRedisCache.NEVER_EXPIRE
+    }
+
+    def 'it should set expiration on all caches with configured ttl when creating a cache manager.'() {
+        given:
+        Long ttl = 5
+        RedisTemplate template = Mock(RedisTemplate)
+        GrailsRedisCacheManager cacheManager = new GrailsRedisCacheManager(template)
+
+        when: cacheManager.setTimeToLive(ttl)
+
+        and: GrailsRedisCache cache = cacheManager.getCache('book')
+
+        then:
+
+        assert cache.ttl == ttl
+    }
+}

--- a/test/unit/grails/plugin/cache/redis/GrailsRedisCacheSpec.groovy
+++ b/test/unit/grails/plugin/cache/redis/GrailsRedisCacheSpec.groovy
@@ -1,0 +1,41 @@
+package grails.plugin.cache.redis
+
+import org.springframework.data.redis.cache.DefaultRedisCachePrefix
+import org.springframework.data.redis.cache.RedisCachePrefix
+import org.springframework.data.redis.core.RedisTemplate
+import spock.lang.Specification
+
+class GrailsRedisCacheSpec extends Specification {
+
+    def 'it should default expiration to never expire when creating a cache with a null ttl value.'() {
+        given:
+        RedisCachePrefix cachePrefix = new DefaultRedisCachePrefix()
+        String cacheName = 'book'
+        byte[] prefix = cachePrefix.prefix(cacheName)
+        RedisTemplate template = Mock(RedisTemplate)
+        Long ttl = null
+
+        when: GrailsRedisCache cache = new GrailsRedisCache(cacheName, prefix, template, ttl)
+
+        then:
+
+        assert cache.ttl == GrailsRedisCache.NEVER_EXPIRE
+    }
+
+    def 'it should set expiration with configured ttl when creating a cache.'() {
+        given:
+        RedisCachePrefix cachePrefix = new DefaultRedisCachePrefix()
+        String cacheName = 'book'
+        byte[] prefix = cachePrefix.prefix(cacheName)
+        RedisTemplate template = Mock(RedisTemplate)
+        Long ttl = 500
+
+        when: GrailsRedisCache cache = new GrailsRedisCache(cacheName, prefix, template, ttl)
+
+        then:
+
+        assert cache.ttl == ttl
+    }
+
+
+}


### PR DESCRIPTION
An initial attempt at implementing a TTL configuration for the Grails Cache Redis Plugin.

The following would provide the ability to globally configure a TTL for all Redis caches.  I would much prefer the ability to set this at a per cache level, but had some trouble making it work with current cache config parsing.  Would be happy to add that ability after a discussion of how best to accomplish.

I borrowed the logic from Spring Data Redis' implementation:
https://github.com/spring-projects/spring-data-redis/blob/master/src/main/java/org/springframework/data/redis/cache/RedisCacheManager.java

Thoughts?  Concerns?