### PR TITLE
ci: restore ci branch triggers

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -2,10 +2,10 @@ name: "Java CI"
 on:
   push:
     branches:
-      - '[6-9]+.x'
+      - '[6-9]+.[0-9]+.x'
   pull_request:
     branches:
-      - '[6-9]+.x'
+      - '[6-9]+.[0-9]+.x'
   workflow_dispatch:
 jobs:
   test_project:


### PR DESCRIPTION
As the branch is now renamed to `6.0.x`.